### PR TITLE
bump deps version and deprecated api:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ exclude = ["assets/*", "examples/*", "runs/*", "benches/*"]
 
 [dependencies]
 aksr = { version = "0.0.2" }
-image = { version = "0.25.2" }
-imageproc = { version = "0.24" }
+image = { version = "0.25" }
+imageproc = { version = "0.25" }
 ndarray = { version = "0.16.1", features = ["rayon", "serde"] }
 rayon = { version = "1.10.0" }
-anyhow = { version = "1.0.75" }
-regex = { version = "1.5.4" }
+anyhow = { version = "1.0" }
+regex = { version = "1.11.1" }
 rand = { version = "0.8.5" }
 chrono = { version = "0.4.30" }
 tokenizers = { version = "0.21.0" }
@@ -26,17 +26,17 @@ indicatif = "0.17.8"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 ort = { version = "2.0.0-rc.9", default-features = false}
-prost = "0.12.4"
-ab_glyph = "0.2.23"
-dirs = { version = "5.0.1" }
-tempfile = "3.12.0"
-geo = "0.28.0"
+prost = "0.12.6"
+ab_glyph = "0.2.29"
+tempfile = "3.19.1"
+dirs = "6.0.0"
+geo = "0.30.0"
+natord = "1.0.9"
 half = { version = "2.3.1" }
 ureq = { version = "2.12.1", default-features = false, features = [ "tls" ] }
-fast_image_resize = { version = "4.2.1", features = ["image"]}
-natord = "1.0.9"
-video-rs = { version = "0.10.0", features = ["ndarray"], optional = true }
-minifb = { version = "0.27.0", optional = true }
+fast_image_resize = { version = "5.1.2", features = ["image"]}
+video-rs = { version = "0.10.3", features = ["ndarray"], optional = true }
+minifb = { version = "0.28.0", optional = true }
 sha2 = "0.10.8"
 ndarray-npy = "0.9.1"
 

--- a/src/xy/mbr.rs
+++ b/src/xy/mbr.rs
@@ -1,5 +1,5 @@
 use aksr::Builder;
-use geo::{coord, line_string, Area, BooleanOps, Coord, EuclideanDistance, LineString, Polygon};
+use geo::{coord, line_string, Area, BooleanOps, Coord, Distance, Euclidean, LineString, Polygon};
 
 use crate::Nms;
 
@@ -163,8 +163,9 @@ impl Mbr {
 
     pub fn distance_min_max(&self) -> (f32, f32) {
         let ls = self.vertices();
-        let min = ls[0].euclidean_distance(&ls[1]);
-        let max = ls[1].euclidean_distance(&ls[2]);
+        // "Please use the `Euclidean.distance` method from the `Distance` trait instead"
+        let min = Euclidean.distance(ls[0], ls[1]);
+        let max = Euclidean.distance(ls[1], ls[2]);
         if min < max {
             (min as f32, max as f32)
         } else {

--- a/src/xy/polygon.rs
+++ b/src/xy/polygon.rs
@@ -1,6 +1,6 @@
 use aksr::Builder;
 use geo::{
-    coord, point, polygon, Area, BoundingRect, Centroid, ConvexHull, EuclideanLength, LineString,
+    coord, point, polygon, Area, BoundingRect, Centroid, ConvexHull, Euclidean, Length, LineString,
     MinimumRotatedRect, Point, Simplify,
 };
 
@@ -90,7 +90,8 @@ impl Polygon {
     }
 
     pub fn perimeter(&self) -> f64 {
-        self.polygon.exterior().euclidean_length()
+        // use the `line.length::<Euclidean>()` via the `Length` trait instead.
+        Euclidean.length(self.polygon.exterior())
     }
 
     pub fn area(&self) -> f64 {


### PR DESCRIPTION
image: 0.25.2 -> 0.25
imageproc: 0.24 -> 0.25
anyhow: 1.0.75 -> 1.0
## Specific version
regex: 1.5.4 -> 1.11.1
prost: 0.12.4 -> 0.12.6
ab_glyph: 0.2.23 -> 0.2.29
tempfile: 3.12.0 -> 3.19.1
dirs: 5.0.1 -> 6.0.0
geo: 0.28.0 -> 0.30.0
minifb: 0.27.0 -> 0.28.0
fast_image_resize: 4.2.1 -> 5.1.2