### PR TITLE
refactor(Drawable): impl Drawable for slice

### DIFF
--- a/src/viz/annotator.rs
+++ b/src/viz/annotator.rs
@@ -31,7 +31,10 @@ impl Default for Annotator {
 }
 
 impl Annotator {
-    pub fn annotate<T: Drawable>(&self, image: &Image, drawable: &T) -> Result<Image> {
+    pub fn annotate<T>(&self, image: &Image, drawable: &T) -> Result<Image>
+    where
+        T: Drawable + ?Sized,
+    {
         let ctx = DrawContext {
             text_renderer: &self.text_renderer,
             prob_style: self.prob_style.as_ref(),

--- a/src/viz/drawable/hbb.rs
+++ b/src/viz/drawable/hbb.rs
@@ -4,7 +4,7 @@ use image::{Rgba, RgbaImage};
 
 use crate::{DrawContext, Hbb, Style, TextLoc};
 
-impl Drawable for Vec<Hbb> {
+impl Drawable for [Hbb] {
     fn draw(&self, ctx: &DrawContext, canvas: &mut RgbaImage) -> Result<()> {
         self.iter().try_for_each(|x| x.draw(ctx, canvas))
     }

--- a/src/viz/drawable/keypoint.rs
+++ b/src/viz/drawable/keypoint.rs
@@ -91,7 +91,7 @@ impl Drawable for Keypoint {
     }
 }
 
-impl Drawable for Vec<Keypoint> {
+impl Drawable for [Keypoint] {
     fn draw(&self, ctx: &DrawContext, canvas: &mut RgbaImage) -> Result<()> {
         let nk = self.len();
         if nk > 0 {
@@ -137,7 +137,7 @@ impl Drawable for Vec<Keypoint> {
     }
 }
 
-impl Drawable for Vec<Vec<Keypoint>> {
+impl Drawable for [Vec<Keypoint>] {
     fn draw(&self, ctx: &DrawContext, canvas: &mut RgbaImage) -> Result<()> {
         self.iter().try_for_each(|x| x.draw(ctx, canvas))
     }

--- a/src/viz/drawable/mask.rs
+++ b/src/viz/drawable/mask.rs
@@ -70,7 +70,7 @@ fn draw_masks(
     Ok(())
 }
 
-impl Drawable for Vec<Mask> {
+impl Drawable for [Mask] {
     fn get_global_style<'a>(&self, ctx: &'a DrawContext) -> Option<&'a Style> {
         ctx.mask_style
     }

--- a/src/viz/drawable/mod.rs
+++ b/src/viz/drawable/mod.rs
@@ -86,6 +86,45 @@ impl Drawable for Y {
     }
 }
 
+impl<T> Drawable for Vec<T>
+where
+    [T]: Drawable,
+{
+    fn get_local_style(&self) -> Option<&Style> {
+        self.as_slice().get_local_style()
+    }
+
+    fn get_global_style<'a>(&self, ctx: &'a DrawContext) -> Option<&'a Style> {
+        self.as_slice().get_global_style(ctx)
+    }
+
+    fn get_id(&self) -> Option<usize> {
+        self.as_slice().get_id()
+    }
+
+    fn draw_shapes_with_style(
+        &self,
+        ctx: &DrawContext,
+        canvas: &mut image::RgbaImage,
+        style: &Style,
+    ) -> anyhow::Result<()> {
+        self.as_slice().draw_shapes_with_style(ctx, canvas, style)
+    }
+
+    fn draw_texts_with_style(
+        &self,
+        ctx: &DrawContext,
+        canvas: &mut image::RgbaImage,
+        style: &Style,
+    ) -> anyhow::Result<()> {
+        self.as_slice().draw_texts_with_style(ctx, canvas, style)
+    }
+
+    fn draw(&self, ctx: &DrawContext, canvas: &mut image::RgbaImage) -> anyhow::Result<()> {
+        self.as_slice().draw(ctx, canvas)
+    }
+}
+
 // impl<T: Drawable> Drawable for Vec<T> {
 //     fn draw_shapes(&self, ctx: &DrawContext, canvas: &mut image::RgbaImage) ->  anyhow::Result<()> {
 //         self.iter().try_for_each(|x| x.draw_shapes(ctx, canvas))

--- a/src/viz/drawable/obb.rs
+++ b/src/viz/drawable/obb.rs
@@ -4,7 +4,7 @@ use image::{Rgba, RgbaImage};
 
 use crate::{DrawContext, Obb, Style, TextLoc};
 
-impl Drawable for Vec<Obb> {
+impl Drawable for [Obb] {
     fn draw(&self, ctx: &DrawContext, canvas: &mut RgbaImage) -> Result<()> {
         self.iter().try_for_each(|x| x.draw(ctx, canvas))
     }

--- a/src/viz/drawable/polygon.rs
+++ b/src/viz/drawable/polygon.rs
@@ -4,7 +4,7 @@ use image::{Rgba, RgbaImage};
 
 use crate::{DrawContext, Polygon, Style, TextLoc};
 
-impl Drawable for Vec<Polygon> {
+impl Drawable for [Polygon] {
     fn draw(&self, ctx: &DrawContext, canvas: &mut RgbaImage) -> Result<()> {
         self.iter().try_for_each(|x| x.draw(ctx, canvas))
     }

--- a/src/viz/drawable/prob.rs
+++ b/src/viz/drawable/prob.rs
@@ -4,7 +4,7 @@ use image::RgbaImage;
 
 use crate::{DrawContext, Prob, Style, TextLoc};
 
-impl Drawable for Vec<Prob> {
+impl Drawable for [Prob] {
     fn draw_texts_with_style(
         &self,
         ctx: &DrawContext,


### PR DESCRIPTION
`Drawable` is implemented for `Vec<T>` so far, which means users have to create type Vec to get its reference for `&Drawable`. It's wired when we actually need a slice in `Drawable`'s methods. So I migrate the implementation to slice and forward `Vec<T>`'s methods to slice's.