### PR TITLE
Add access to frame rate for loaded video.  Allow setting filename of save out.

### DIFF
--- a/src/core/dataloader.rs
+++ b/src/core/dataloader.rs
@@ -40,6 +40,10 @@ pub struct DataLoader {
     #[cfg(feature = "video")]
     nf_skip: u64,
 
+    /// Frame rate for video or stream.
+    #[cfg(feature = "video")]
+    frame_rate: f32,
+
     /// Progress bar for displaying iteration progress.
     progress_bar: Option<ProgressBar>,
 
@@ -146,7 +150,8 @@ impl DataLoader {
                 Err(_) => u64::MAX,
                 Ok(0) => u64::MAX,
                 Ok(x) => x,
-            }
+            };
+            frame_rate = decoder.frame_rate();
         }
 
         // info
@@ -166,11 +171,6 @@ impl DataLoader {
             decoder,
             ..Default::default()
         })
-    }
-
-    #[cfg(feature = "video")]
-    pub fn video_decoder(&self) -> Option<&video_rs::decode::Decoder> {
-        self.decoder.as_ref()
     }
 
     pub fn build(mut self) -> Result<Self> {
@@ -503,6 +503,11 @@ impl DataLoader {
     #[cfg(feature = "video")]
     pub fn nf_skip(&self) -> u64 {
         self.nf_skip
+    }
+
+    #[cfg(feature = "video")]
+    pub fn frame_rate(&self) -> f32 {
+        self.frame_rate
     }
 
     pub fn with_progress_bar(mut self, x: bool) -> Self {

--- a/src/core/dataloader.rs
+++ b/src/core/dataloader.rs
@@ -168,6 +168,11 @@ impl DataLoader {
         })
     }
 
+    #[cfg(feature = "video")]
+    pub fn video_decoder(&self) -> Option<&video_rs::decode::Decoder> {
+        self.decoder.as_ref()
+    }
+
     pub fn build(mut self) -> Result<Self> {
         let (sender, receiver) =
             mpsc::sync_channel::<Vec<Image>>(self.bound.unwrap_or(self.batch_size * 10));

--- a/src/core/dataloader.rs
+++ b/src/core/dataloader.rs
@@ -66,6 +66,8 @@ impl Default for DataLoader {
             with_progress_bar: false,
             #[cfg(feature = "video")]
             decoder: None,
+            #[cfg(feature = "video")]
+            frame_rate: 25.0,
         }
     }
 }
@@ -145,6 +147,9 @@ impl DataLoader {
 
         // video & stream frames
         #[cfg(feature = "video")]
+        let mut frame_rate = 0.0;
+
+        #[cfg(feature = "video")]
         if let Some(decoder) = &decoder {
             nf = match decoder.frames() {
                 Err(_) => u64::MAX,
@@ -167,6 +172,8 @@ impl DataLoader {
             paths,
             media_type,
             nf,
+            #[cfg(feature = "video")]
+            frame_rate,
             #[cfg(feature = "video")]
             decoder,
             ..Default::default()

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -154,7 +154,7 @@ pub fn generate_random_string(length: usize) -> String {
 ///
 /// # Arguments
 /// * `delimiter` - Optional string to insert between each component of the timestamp.
-///                If None or empty string, components will be joined without delimiter.
+///   If None or empty string, components will be joined without delimiter.
 ///
 /// # Returns
 /// A string containing the current timestamp with the specified format.

--- a/src/viz/viewer.rs
+++ b/src/viz/viewer.rs
@@ -244,6 +244,12 @@ impl Viewer<'_> {
         self
     }
 
+    #[cfg(feature = "video")]
+    pub fn with_saveout(mut self, x: String) -> Self {
+        self.saveout = Some(x);
+        self
+    }
+
     #[inline]
     pub fn width_height(&self) -> Option<(usize, usize)> {
         self.window.as_ref().map(|x| x.get_size())


### PR DESCRIPTION
Added frame_rate as video feature in DataLoader
Added with_saveout as video feature in Viewer
Fixed compile issue by using newer version of Rust.