### PR TITLE
[WIP] Split out minifb, viewer, and possibly other things into features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ imageproc = { version = "0.25" }
 ndarray = { version = "0.16.1", features = ["rayon", "serde"] }
 indicatif = { version = "0.17.11" }
 log = "0.4.26"
-minifb = { version = "0.28.0" }
+minifb = { version = "0.28.0", optional = true }
 rand = { version = "0.9" }
 http = "1.3"
 ureq = { version = "3" }
@@ -47,8 +47,6 @@ ort = { version = "=2.0.0-rc.10", default-features = false, optional = true, fea
 hf-hub = { version = "0.4.3", default-features = false, features = ["ureq", "native-tls"] }
 tokenizers = { version = "0.21.1" }
 paste = "1.0.15"
-base64ct = "=1.7.3"
-once_cell = "1.20"
 
 
 [dev-dependencies]
@@ -57,7 +55,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "chrono"] }
 
 
 [features]
-default = [ "ort-download-binaries" ]
+default = [ "ort-download-binaries", "viewer" ]
 serde = []
 video = [ "dep:video-rs" ]
 ort-download-binaries = [ "ort", "ort/download-binaries" ]
@@ -80,3 +78,13 @@ qnn = [ "ort/qnn" ]
 migraphx = [ "ort/migraphx" ]
 vitis = [ "ort/vitis" ]
 azure = [ "ort/azure" ]
+viewer = [ "dep:minifb" ]
+
+
+[[example]]
+name = "read_video"
+required-features = ["video"]
+
+[[example]]
+name = "imshow"
+required-features = ["viewer"]

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ usls = "latest-version"
 ## 📦 Cargo Features
 - **`ort-download-binaries`** (**default**): Automatically downloads prebuilt ONNXRuntime binaries for supported platforms
 - **`ort-load-dynamic`**: Dynamic linking to ONNXRuntime libraries ([Guide](https://ort.pyke.io/setup/linking#dynamic-linking))
-- **`video`**: Enable video stream reading and writing (via [video-rs](https://github.com/oddity-ai/video-rs) and [minifb](https://github.com/emoon/rust_minifb))
+- **`video`**: Enable video stream reading and writing (via [video-rs](https://github.com/oddity-ai/video-rs))
+- **`viewer`**: Enable image and video stream visualization (via [minifb](https://github.com/emoon/rust_minifb))
 - **`cuda`**: NVIDIA CUDA GPU acceleration support
 - **`tensorrt`**: NVIDIA TensorRT optimization for inference acceleration
 - **`coreml`**: Apple CoreML acceleration for macOS/iOS devices

--- a/src/core/global_ts.rs
+++ b/src/core/global_ts.rs
@@ -1,4 +1,3 @@
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -299,7 +298,8 @@ impl GlobalTsManager {
 }
 
 /// Global singleton instance
-static GLOBAL_TS_MANAGER: Lazy<GlobalTsManager> = Lazy::new(GlobalTsManager::new);
+static GLOBAL_TS_MANAGER: std::sync::LazyLock<GlobalTsManager> =
+    std::sync::LazyLock::new(GlobalTsManager::new);
 
 /// Get the global Ts manager instance
 pub fn global_ts_manager() -> &'static GlobalTsManager {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@
 //! ## ⚡ Cargo Features
 //! - **`ort-download-binaries`** (**default**): Automatically downloads prebuilt ONNXRuntime binaries for supported platforms
 //! - **`ort-load-dynamic`**: Dynamic linking to ONNXRuntime libraries ([Guide](https://ort.pyke.io/setup/linking#dynamic-linking))
-//! - **`video`**: Enable video stream reading and writing (via [video-rs](https://github.com/oddity-ai/video-rs) and [minifb](https://github.com/emoon/rust_minifb))
+//! - **`video`**: Enable video stream reading and writing (via [video-rs](https://github.com/oddity-ai/video-rs)
+//! - **`viewer`**: Enable image and video stream visualization (via [minifb](https://github.com/emoon/rust_minifb))
 //! - **`cuda`**: NVIDIA CUDA GPU acceleration support
 //! - **`tensorrt`**: NVIDIA TensorRT optimization for inference acceleration
 //! - **`coreml`**: Apple CoreML acceleration for macOS/iOS devices
@@ -49,7 +50,6 @@
 //!
 
 pub mod core;
-/// Model Zoo
 #[cfg(any(feature = "ort-download-binaries", feature = "ort-load-dynamic"))]
 pub mod models;
 #[macro_use]
@@ -57,6 +57,7 @@ mod results;
 pub mod viz;
 
 pub use core::*;
+#[cfg(feature = "viewer")]
 pub use minifb::Key;
 #[cfg(any(feature = "ort-download-binaries", feature = "ort-load-dynamic"))]
 pub use models::*;

--- a/src/viz/mod.rs
+++ b/src/viz/mod.rs
@@ -15,4 +15,5 @@ pub use draw_ctx::*;
 pub use drawable::*;
 pub use styles::*;
 pub use text_renderer::*;
+#[cfg(feature = "viewer")]
 pub use viewer::*;


### PR DESCRIPTION
what: splitting out things into on-by-default features
why: to not include unnecessary components in the supply chain and not increase binary size and compilation time for no reason

draft since the ureq split isn't exactly perfect yet