### PR TITLE
Change frames per second (fps) from usize to f32 

### DIFF
--- a/src/viz/viewer.rs
+++ b/src/viz/viewer.rs
@@ -150,7 +150,7 @@ impl Viewer<'_> {
             )?;
             self.position = self
                 .position
-                .aligned_with(Time::from_secs(1.0/self.fps))
+                .aligned_with(Time::from_secs(1.0 / self.fps))
                 .add();
         }
 


### PR DESCRIPTION
Some videos have frame rates like 29.97 and so fps needs to be represented as a float.