### PR TITLE
Add YOLOE-26 prompt-free and prompt-based models

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ cargo run -r --example yolo -- --help
 
 > **Status:** ✅ **Supported**  |  ❓ **Unknown**  |  ❌ **Not Supported For Now**
 
+🔍 All ONNX models are available from the [ONNX Models Repository](https://github.com/jamjamjon/assets)
+
 <details closed>
 <summary><b>🔥 YOLO-Series</b></summary>
 
@@ -239,6 +241,7 @@ cargo run -r --example yolo -- --help
 | [OWLv2](https://huggingface.co/google/owlv2-base-patch16-ensemble) | Open-Set Object Detection | [demo](./examples/open-set-detection) | ✅ | ❓  | ✅ | ✅   | ❌ | ❌ | ❌ |
 | [YOLO-World](https://github.com/AILab-CVC/YOLO-World) | Open-Set Detection With Language | [demo](./examples/yolo) | ✅ | ✅ |✅  | ✅  | ✅  | ✅  | ✅  |
 | [YOLOE-Prompt-Based](https://github.com/THU-MIG/yoloe) | Open-Set Detection And Segmentation | [demo](./examples/open-set-segmentation) | ✅ | ✅ | ✅  | ✅  | ✅  | ✅  | ✅  |
+| [YOLOE-26-Prompt-Based](https://github.com/ultralytics/ultralytics) | Open-Set Detection And Segmentation | [demo](./examples/open-set-segmentation) | ✅ | ✅ | ✅  | ✅  | ✅  | ✅  | ✅  |
 | [SAM3-Image](https://github.com/facebookresearch/segment-anything-3) | Open-Set Detection And Segmentation| [demo](./examples/open-set-segmentation) | ✅ | ✅ | ✅  | ✅  | ✅  | ✅  | ✅  |
 
 </details>

--- a/examples/open-set-segmentation/README.md
+++ b/examples/open-set-segmentation/README.md
@@ -9,7 +9,7 @@ The latest generation of Segment Anything Model (SAM3) optimized for image-based
 - Supports both text prompts and geometry (point/box) prompts.
 - Advanced hierarchical feature extraction.
 
-### YOLOEPrompt
+### YOLOEPromptBased
 YOLOE with prompt support for flexible object detection and segmentation.
 - `Visual`: Uses a visual prompt (image + bounding box) to find similar objects.
 - `Textual`: Uses text descriptions to segment objects.
@@ -18,28 +18,26 @@ YOLOE with prompt support for flexible object detection and segmentation.
 ## Examples
 
 
-### YOLOE-Prompt
+### yoloe-prompt-based
 
 #### # Visual prompt
 
 ```bash
-cargo run -F cuda-full -F vlm --example open-set-segmentation -- yoloe-prompt \
---model-dtype q4f16 --model-device cuda:0 \
+cargo run -F cuda-full -F vlm --example open-set-segmentation -- yoloe-prompt-based \
+--model-dtype fp32 --model-device cuda:0 \
 --visual-encoder-dtype q4f16 --visual-encoder-device cuda:0 \
---textual-encoder-dtype q4f16 --textual-encoder-device cuda:0 \
 --processor-device cuda:0 \
 --source ./assets/bus.jpg \
---kind visual
+--kind visual --ver 26 --scale s
 ```
 
 
 #### Textual prompt
 
 ```bash
-cargo run -F cuda-full -F vlm --example open-set-segmentation -- yoloe-prompt \
---model-dtype q4f16 --model-device cuda:0 \
---visual-encoder-dtype q4f16 --visual-encoder-device cuda:0 \
---textual-encoder-dtype q4f16 --textual-encoder-device cuda:0 \
+cargo run -F cuda-full -F vlm --example open-set-segmentation -- yoloe-prompt-based \
+--model-dtype fp32 --model-device cuda:0 \
+--textual-encoder-dtype f16 --textual-encoder-device cuda:0 \
 --processor-device cuda:0 \
 --kind textual -p person -p bus
 ```

--- a/examples/open-set-segmentation/main.rs
+++ b/examples/open-set-segmentation/main.rs
@@ -1,16 +1,16 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use usls::{
-    models::{Sam3Image, Sam3Prompt, YOLOEPrompt},
+    models::{Sam3Image, Sam3Prompt, YOLOEPromptBased},
     Annotator, Config, DataLoader, Hbb, Model, Source,
 };
 
 mod sam3_image;
 #[path = "../utils/mod.rs"]
 mod utils;
-mod yoloe_prompt;
+mod yoloe_prompt_based;
 
-use crate::yoloe_prompt::Kind;
+use crate::yoloe_prompt_based::Kind;
 
 #[derive(Parser)]
 #[command(author, version, about = "Open-Set Segmentation Examples")]
@@ -34,7 +34,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    YOLOEPrompt(yoloe_prompt::YoloePromptArgs),
+    YOLOEPromptBased(yoloe_prompt_based::YoloePromptArgs),
     Sam3Image(sam3_image::Sam3ImageArgs),
 }
 
@@ -57,12 +57,11 @@ fn main() -> Result<()> {
                 .commit()?;
             run_sam3_image(config, cli.source, &annotator, args, &cli.prompts)?
         }
-
-        Commands::YOLOEPrompt(args) => {
-            let config = yoloe_prompt::config(args)?
+        Commands::YOLOEPromptBased(args) => {
+            let config = yoloe_prompt_based::config(args)?
                 .with_class_confs(&cli.confs)
                 .commit()?;
-            run_yoloe_prompt(config, cli.source, &annotator, args, &cli.prompts)?
+            run_yoloe_prompt_based(config, cli.source, &annotator, args, &cli.prompts)?
         }
     }
     usls::perf(false);
@@ -70,14 +69,14 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn run_yoloe_prompt(
+fn run_yoloe_prompt_based(
     config: Config,
     source: Source,
     annotator: &Annotator,
-    args: &yoloe_prompt::YoloePromptArgs,
+    args: &yoloe_prompt_based::YoloePromptArgs,
     prompts: &[String],
 ) -> Result<()> {
-    let mut model = YOLOEPrompt::new(config)?;
+    let mut model = YOLOEPromptBased::new(config)?;
 
     // Encode embedding
     let embedding = match args.kind {

--- a/examples/open-set-segmentation/yoloe_prompt_based.rs
+++ b/examples/open-set-segmentation/yoloe_prompt_based.rs
@@ -92,7 +92,7 @@ pub fn config(args: &YoloePromptArgs) -> Result<Config> {
         (26, Scale::L, Kind::Textual) => Config::yoloe_26l_seg_tp(),
         (26, Scale::X, Kind::Textual) => Config::yoloe_26x_seg_tp(),
         _ => anyhow::bail!(
-            "Unsupported version {}, scale {}, kind {:?}. Try v8/v11 with s, m, l. and visual/textual.",
+            "Unsupported version {}, scale {}, kind {:?}. Try v8/v11 with s, m, l, 26 with n, s, m, l, x and visual/textual.",
             args.ver,
             args.scale,
             args.kind

--- a/src/models/vlm/yoloe/config.rs
+++ b/src/models/vlm/yoloe/config.rs
@@ -8,6 +8,7 @@ use crate::{Config, Scale, Version};
 /// > # Paper & Code
 /// >
 /// > - **GitHub**: [THU-MIG/yoloe](https://github.com/THU-MIG/yoloe)
+/// > - **GitHub**: [ultralytics/YOLOE-26](https://github.com/ultralytics/ultralytics)
 /// >
 /// > # Model Variants
 /// >
@@ -15,15 +16,15 @@ use crate::{Config, Scale, Version};
 /// > - **yoloe-11s/m/l-seg-tp**: YOLOE 11 text-prompt segmentation models
 /// > - **yoloe-v8s/m/l-seg-vp**: YOLOE v8 visual-prompt segmentation models
 /// > - **yoloe-11s/m/l-seg-vp**: YOLOE 11 visual-prompt segmentation models
+/// > - **yoloe-26n/m/s/m/l/x-seg-tp**: YOLOE 26 text-prompt segmentation models
+/// > - **yoloe-26n/m/s/m/l/x-seg-vp**: YOLOE 26 visual-prompt segmentation models
 /// >
 /// > # Implemented Features / Tasks
 /// >
 /// > - [X] **Text-Prompt Segmentation**: Segment objects described by text
 /// > - [X] **Visual-Prompt Segmentation**: Segment with visual prompts
-/// > - [X] **Real-Time Performance**: Optimized for real-time inference
-/// > - [X] **Multi-Scale Support**: Various model sizes (S/M/L)
 /// >
-/// Model configuration for `YOLOE`
+/// Model configuration for `YOLOE` with prompt-based inference.
 ///
 impl Config {
     /// Base configuration for YOLOE text-prompt segmentation
@@ -31,7 +32,7 @@ impl Config {
         Self::yoloe()
             .with_batch_size_all(1)
             .with_nc(80)
-            .with_model_ixx(1, 1, (1, 80, 300)) // max nc
+            .with_model_ixx(1, 1, (1, 80, 300)) // max nc/ max dets
             .with_model_max_length(77)
             .with_textual_encoder_ixx(0, 1, 77)
             .with_textual_encoder_file("mobileclip/blt-textual.onnx")
@@ -88,36 +89,46 @@ impl Config {
             .with_model_file("yoloe-11l-seg-prompt.onnx")
     }
 
+    /// Base configuration for YOLOE 26 text-prompt segmentation
+    fn yoloe_26_seg_tp() -> Self {
+        Self::yoloe_seg_tp().with_textual_encoder_file("mobileclip2/b-textual.onnx")
+    }
+
+    /// YOLOE 26 small text-prompt segmentation model
     pub fn yoloe_26n_seg_tp() -> Self {
-        Self::yoloe_seg_tp()
+        Self::yoloe_26_seg_tp()
             .with_version(Version::from(26))
             .with_scale(Scale::N)
             .with_model_file("yoloe-26n-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 small text-prompt segmentation model
     pub fn yoloe_26s_seg_tp() -> Self {
-        Self::yoloe_seg_tp()
+        Self::yoloe_26_seg_tp()
             .with_version(Version::from(26))
             .with_scale(Scale::S)
             .with_model_file("yoloe-26s-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 medium text-prompt segmentation model
     pub fn yoloe_26m_seg_tp() -> Self {
-        Self::yoloe_seg_tp()
+        Self::yoloe_26_seg_tp()
             .with_version(Version::from(26))
             .with_scale(Scale::M)
             .with_model_file("yoloe-26m-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 large text-prompt segmentation model
     pub fn yoloe_26l_seg_tp() -> Self {
-        Self::yoloe_seg_tp()
+        Self::yoloe_26_seg_tp()
             .with_version(Version::from(26))
             .with_scale(Scale::L)
             .with_model_file("yoloe-26l-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 extra large text-prompt segmentation model
     pub fn yoloe_26x_seg_tp() -> Self {
-        Self::yoloe_seg_tp()
+        Self::yoloe_26_seg_tp()
             .with_version(Version::from(26))
             .with_scale(Scale::X)
             .with_model_file("yoloe-26x-seg-prompt.onnx")
@@ -197,6 +208,7 @@ impl Config {
             .with_model_file("yoloe-11l-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 small visual-prompt segmentation model
     pub fn yoloe_26n_seg_vp() -> Self {
         Self::yoloe_seg_vp()
             .with_version(Version::from(26))
@@ -205,6 +217,7 @@ impl Config {
             .with_model_file("yoloe-26n-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 medium visual-prompt segmentation model
     pub fn yoloe_26s_seg_vp() -> Self {
         Self::yoloe_seg_vp()
             .with_version(Version::from(26))
@@ -213,6 +226,7 @@ impl Config {
             .with_model_file("yoloe-26s-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 medium visual-prompt segmentation model
     pub fn yoloe_26m_seg_vp() -> Self {
         Self::yoloe_seg_vp()
             .with_version(Version::from(26))
@@ -221,6 +235,7 @@ impl Config {
             .with_model_file("yoloe-26m-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 large visual-prompt segmentation model
     pub fn yoloe_26l_seg_vp() -> Self {
         Self::yoloe_seg_vp()
             .with_version(Version::from(26))
@@ -229,6 +244,7 @@ impl Config {
             .with_model_file("yoloe-26l-seg-prompt.onnx")
     }
 
+    /// YOLOE 26 extra large visual-prompt segmentation model
     pub fn yoloe_26x_seg_vp() -> Self {
         Self::yoloe_seg_vp()
             .with_version(Version::from(26))

--- a/src/models/vlm/yoloe/mod.rs
+++ b/src/models/vlm/yoloe/mod.rs
@@ -1,4 +1,5 @@
 mod config;
 mod r#impl;
 
-pub use r#impl::YOLOEPrompt;
+pub use r#impl::YOLOEPromptBased;
+pub type YOLOE = YOLOEPromptBased;

--- a/src/models/vlm/yoloe/prompt.rs
+++ b/src/models/vlm/yoloe/prompt.rs
@@ -1,0 +1,8 @@
+use crate::Hbb;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Default)]
+pub struct YOLOEPrompt {
+    pub texts: Vec<String>,
+    pub boxes: Vec<(Hbb, PathBuf)>,
+}


### PR DESCRIPTION
- Add YOLOE-26n/s/m/l/x-seg-tp models: YOLOE-26 text-prompt–based segmentation models
- Add YOLOE-26n/s/m/l/x-seg-vp models: YOLOE-26 visual-prompt–based segmentation models
- Rename YOLOEPrompt to YOLOEPromptBased, and add an alias: YOLOE = YOLOEPromptBased