### PR TITLE
Change default visual encoder dtype to int4

### DIFF
--- a/examples/vlm/moondream2.rs
+++ b/examples/vlm/moondream2.rs
@@ -9,7 +9,7 @@ pub struct Moondream2Args {
     pub scale: Scale,
 
     /// Visual Encoder Dtype: int4 int8
-    #[arg(long, default_value = "fp16")]
+    #[arg(long, default_value = "int4")]
     pub visual_encoder_dtype: DType,
 
     /// Visual Encoder Device: cpu, cuda:0, mps, coreml, openvino:CPU, etc.


### PR DESCRIPTION
Comment says "int4 int8" so I guess it's a typo

Also doesn't seem that the fp16 file is existing on github files

Thanks for this wonderful project!