### PR TITLE
fix(sam3_image): prevent unwrap panic caused by LruCache eviction during mixed queries

### DIFF
--- a/src/models/vlm/sam3_image/impl.rs
+++ b/src/models/vlm/sam3_image/impl.rs
@@ -348,24 +348,27 @@ impl Sam3Image {
             let mut uncached = Vec::new();
             let mut seen = HashSet::new();
             for p in prompts {
-                if seen.insert(&p.text) {
-                    if self.text_cache.get(&p.text).is_none() {
-                        uncached.push(p.text.as_str());
-                    }
+                if seen.insert(&p.text) && self.text_cache.get(&p.text).is_none() {
+                    uncached.push(p.text.as_str());
                 }
             }
 
             let unique_prompts_count = seen.len();
             if unique_prompts_count > self.text_cache.cap().get() {
                 // If the number of unique prompts in the current batch exceeds the cache capacity, force an expansion.
-                self.text_cache.resize(NonZeroUsize::new(unique_prompts_count).unwrap());
+                self.text_cache
+                    .resize(NonZeroUsize::new(unique_prompts_count).unwrap());
             }
 
             if !uncached.is_empty() {
                 let encoded_feats = self.encode_texts(engines, &uncached)?;
 
                 if encoded_feats.len() != uncached.len() {
-                    bail!("Encoded features length mismatch: expected {}, got {}", uncached.len(), encoded_feats.len());
+                    bail!(
+                        "Encoded features length mismatch: expected {}, got {}",
+                        uncached.len(),
+                        encoded_feats.len()
+                    );
                 }
 
                 for (text, feat) in uncached.iter().zip(encoded_feats) {

--- a/src/models/vlm/sam3_image/impl.rs
+++ b/src/models/vlm/sam3_image/impl.rs
@@ -348,8 +348,10 @@ impl Sam3Image {
             let mut uncached = Vec::new();
             let mut seen = HashSet::new();
             for p in prompts {
-                if seen.insert(&p.text) && !self.text_cache.contains(&p.text) {
-                    uncached.push(p.text.as_str());
+                if seen.insert(&p.text) {
+                    if self.text_cache.get(&p.text).is_none() {
+                        uncached.push(p.text.as_str());
+                    }
                 }
             }
 

--- a/src/models/vlm/sam3_image/impl.rs
+++ b/src/models/vlm/sam3_image/impl.rs
@@ -352,8 +352,21 @@ impl Sam3Image {
                     uncached.push(p.text.as_str());
                 }
             }
+
+            let unique_prompts_count = seen.len();
+            if unique_prompts_count > self.text_cache.cap().get() {
+                // If the number of unique prompts in the current batch exceeds the cache capacity, force an expansion.
+                self.text_cache.resize(NonZeroUsize::new(unique_prompts_count).unwrap());
+            }
+
             if !uncached.is_empty() {
-                for (text, feat) in uncached.iter().zip(self.encode_texts(engines, &uncached)?) {
+                let encoded_feats = self.encode_texts(engines, &uncached)?;
+
+                if encoded_feats.len() != uncached.len() {
+                    bail!("Encoded features length mismatch: expected {}, got {}", uncached.len(), encoded_feats.len());
+                }
+
+                for (text, feat) in uncached.iter().zip(encoded_feats) {
                     self.text_cache.put(text.to_string(), feat);
                 }
             }


### PR DESCRIPTION
🐛 The Bug
Calling `self.text_cache.get(&p.text).unwrap()` occasionally panics with `Option::unwrap()` on a None value.
This happens when:
The number of unique prompts in a single batch exceeds the default LruCache capacity (16).
Or, a previously cached prompt is pushed to the tail (least recently used), and a subsequent query mixes old (tail) prompts with new uncached ones.

🕵️ Root Cause
The original code used `self.text_cache.contains(&p.text)` which only checks existence but does not promote the item to the Most Recently Used (MRU) position.
When new prompts are put() into the cache, the capacity overflows, evicting the oldest items (even if they are about to be accessed in the current batch).
The subsequent unwrap() encounters a None value.

🛠️ The Fix
Promote MRU: Replaced `.contains()` with `.get()`. This inherently promotes accessed items to the front, granting them immunity from eviction during the same batch processing.
Dynamic Resize: Dynamically check `seen.len()`. If it exceeds current capacity, `.resize()` the cache to guarantee the entire batch fits safely.
Avoid Double Encoding: Extracted encode_texts into a variable encoded_feats to prevent running the heavy vision-language model twice for the same inputs.