### PR TITLE
chore(deps): update ort to use onnxruntime 1.27

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -22,8 +22,8 @@ jobs:
           - ""
           - "vision"
           - "vlm"
-          - "ort-download-binaries,ort-api-24"
-          - "ort-load-dynamic,ort-api-24"
+          - "ort-download-binaries,ort-api-27"
+          - "ort-load-dynamic,ort-api-27"
           - "video"
           - "viewer"
           - "annotator"
@@ -49,7 +49,7 @@ jobs:
       - name: Clippy
         run: |
           if [ "${{ matrix.feature }}" = "all-features" ]; then
-            cargo clippy --no-default-features --features "all-models,video,viewer,annotator,ort-download-binaries,ort-load-dynamic,ort-api-24" --all-targets -- -D warnings
+            cargo clippy --no-default-features --features "all-models,video,viewer,annotator,ort-download-binaries,ort-load-dynamic,ort-api-27" --all-targets -- -D warnings
           elif [ "${{ matrix.feature }}" = "" ]; then
             cargo clippy --no-default-features --all-targets -- -D warnings
           else
@@ -74,7 +74,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Check
-        run: cargo check --no-default-features --features "all-models,video,viewer,annotator,ort-download-binaries,ort-load-dynamic,ort-api-24" --all-targets
+        run: cargo check --no-default-features --features "all-models,video,viewer,annotator,ort-download-binaries,ort-load-dynamic,ort-api-27" --all-targets
 
   test:
     name: cargo-test
@@ -94,7 +94,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Test
-        run: cargo +nightly test --no-default-features --features "all-models,video,viewer,annotator,ort-download-binaries,ort-load-dynamic,ort-api-24" --all-targets
+        run: cargo +nightly test --no-default-features --features "all-models,video,viewer,annotator,ort-download-binaries,ort-load-dynamic,ort-api-27" --all-targets
 
   build-linux:
     needs: test
@@ -120,4 +120,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build
-        run: cargo build --no-default-features --features "all-models,video,viewer,annotator,ort-download-binaries,ort-load-dynamic,ort-api-24"
+        run: cargo build --no-default-features --features "all-models,video,viewer,annotator,ort-download-binaries,ort-load-dynamic,ort-api-27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,11 @@ fast_image_resize = { version = "5.5.0", default-features = false, features = ["
 minifb = { version = "0.28.0", optional = true }
 video-rs = { version = "0.11.0", features = ["ndarray"], optional = true }
 ndarray-npy = { version = "0.10", optional = true  }
-ort = { version = "=2.0.0-rc.12", default-features = false, features = [
+ort = { git = "https://github.com/pykeio/ort", rev = "31c8f1443bb579bfddb82705288347697e468fb3", default-features = false, features = [
   "tls-rustls",
   "copy-dylibs",
   "half",
+  "ndarray",
   "std",
 ] }
 cudarc = { version = "0.19", optional = true, default-features = false, features = [
@@ -75,7 +76,7 @@ strip = true
 
 
 [features]
-default = ["ort-download-binaries", "vision", "annotator", "ort-api-24"]
+default = ["ort-download-binaries", "vision", "annotator", "ort-api-27"]
 
 # ONNXRuntime loading strategies
 ort-download-binaries = ["ort/download-binaries"]
@@ -90,6 +91,9 @@ ort-api-21 = ["ort/api-21"]
 ort-api-22 = ["ort/api-22"]
 ort-api-23 = ["ort/api-23"]
 ort-api-24 = ["ort/api-24"]
+ort-api-25 = ["ort/api-25"]
+ort-api-26 = ["ort/api-26"]
+ort-api-27 = ["ort/api-27"]
 
 # Cuda features (Internal use)
 cuda-runtime = ["dep:cudarc"]

--- a/docs/cargo-features/ort.md
+++ b/docs/cargo-features/ort.md
@@ -10,7 +10,7 @@ ONNX Runtime configuration and API version management.
 
 ### API Version Selection
 
-This library supports ONNX Runtime versions 1.17 through 1.24 via API version features.
+This library supports ONNX Runtime versions 1.17 through 1.27 via API version features.
 
 | Feature | ONNX Runtime | Requirements |
 |---------|--------------|--------------|
@@ -21,11 +21,14 @@ This library supports ONNX Runtime versions 1.17 through 1.24 via API version fe
 | `ort-api-21` | v1.21 | - |
 | `ort-api-22` | v1.22 | - |
 | `ort-api-23` | v1.23 | - |
-| `ort-api-24` | v1.24 | **Default** - Latest features |
+| `ort-api-24` | v1.24 | - |
+| `ort-api-25` | v1.25 | - |
+| `ort-api-26` | v1.26 | - |
+| `ort-api-27` | v1.27 | **Default** - Latest features |
 
 !!! tip "API Version Selection"
     ```toml
-    # Default uses api-24 (latest)
+    # Default uses api-27 (latest)
     usls = { version = "0.2", features = ["vision"] }
     
     # Specify API version explicitly

--- a/src/ort/dtype.rs
+++ b/src/ort/dtype.rs
@@ -25,6 +25,7 @@ impl From<TensorElementType> for crate::DType {
             TensorElementType::Complex128 => Self::Complex128,
             TensorElementType::Bool => Self::Uint8,
             TensorElementType::String | TensorElementType::Undefined => Self::Auto,
+            _ => Self::Auto,
         }
     }
 }


### PR DESCRIPTION
- ort 2.0.0-rc.13 has not been released, but I want to use onnxruntime 1.27.
- See https://github.com/pykeio/ort/issues/595 